### PR TITLE
Add version to manifest

### DIFF
--- a/custom_components/tagbox/manifest.json
+++ b/custom_components/tagbox/manifest.json
@@ -8,5 +8,6 @@
         "dependencies": [],
         "codeowners": [
                 "@robmarkcole"
-        ]
+        ],
+        "version": "1.0.0"
 }


### PR DESCRIPTION
Required for Home Assistant 2021.6 as per https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions